### PR TITLE
Added libgbm-devel cdt

### DIFF
--- a/mesa-libgbm-devel-amzn2-aarch64/build.sh
+++ b/mesa-libgbm-devel-amzn2-aarch64/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda-linux-gnu/sysroot
+pushd "${PREFIX}"/aarch64-conda-linux-gnu/sysroot > /dev/null 2>&1
+if [[ "$(ls -A "${SRC_DIR}"/binary)" ]]; then
+  chmod -R +r "${SRC_DIR}"/binary/*
+  cp -Rf "${SRC_DIR}"/binary/* .
+fi

--- a/mesa-libgbm-devel-amzn2-aarch64/meta.yaml
+++ b/mesa-libgbm-devel-amzn2-aarch64/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: mesa-libgbm-devel-amzn2-aarch64
+  version: 18.3.4
+
+source:
+  - url: https://graviton-rpms.s3.amazonaws.com/amzn2-core_2021_01_26/amzn2-core/mesa-libgbm-devel-18.3.4-5.amzn2.0.1.aarch64.rpm
+    sha256: 5e1fe346991587f8c11287f69e0298b6bf55535840e9820d7942cea6bc281533
+    no_hoist: true
+    folder: binary
+
+build:
+  number: 5
+  noarch: generic
+
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - mesa-libgbm-amzn2-aarch64 ==18.3.4
+  host:
+    - mesa-libgbm-amzn2-aarch64 ==18.3.4
+  run:
+    - mesa-libgbm-amzn2-aarch64 ==18.3.4
+
+about:
+  home: http://www.mesa3d.org
+  license: MIT
+  license_family: MIT
+  summary: "(CDT) Mesa gbm development package"
+  description: |
+        Mesa gbm runtime development package.
+
+extras:
+  rpm_name: mesa-libgbm-devel


### PR DESCRIPTION
- Relevant dependency PRs:
  - AnacondaRecipes/qtwebengine-feedstock#1

### Explanation of changes:

- Added cdt for `libgbm-devel` to accompany existing `libgbm` cdt.